### PR TITLE
[IIIF-669] Add navDate to range, canvas

### DIFF
--- a/src/main/java/info/freelibrary/iiif/presentation/Canvas.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Canvas.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import info.freelibrary.iiif.presentation.properties.Label;
+import info.freelibrary.iiif.presentation.properties.NavDate;
 import info.freelibrary.iiif.presentation.properties.Thumbnail;
 import info.freelibrary.iiif.presentation.properties.Type;
 import info.freelibrary.iiif.presentation.utils.Constants;
@@ -38,6 +39,8 @@ public class Canvas extends Resource<Canvas> {
     private List<ImageContent> myImageContent;
 
     private List<OtherContent> myOtherContent;
+
+    private NavDate myNavDate;
 
     /**
      * Creates a IIIF presentation canvas.
@@ -146,6 +149,28 @@ public class Canvas extends Resource<Canvas> {
     public Canvas setHeight(final int aHeight) {
         myHeight = aHeight;
         return this;
+    }
+
+    /**
+     * Sets a navigation date.
+     *
+     * @param aNavDate The navigation date
+     * @return The canvas
+     */
+    @JsonSetter(Constants.NAV_DATE)
+    public Canvas setNavDate(final NavDate aNavDate) {
+        myNavDate = aNavDate;
+        return this;
+    }
+
+    /**
+     * Gets a navigation date.
+     *
+     * @return The navigation date
+     */
+    @JsonGetter(Constants.NAV_DATE)
+    public NavDate getNavDate() {
+        return myNavDate;
     }
 
     /**

--- a/src/main/java/info/freelibrary/iiif/presentation/Range.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Range.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import info.freelibrary.iiif.presentation.properties.Label;
+import info.freelibrary.iiif.presentation.properties.NavDate;
 import info.freelibrary.iiif.presentation.properties.ViewingDirection;
 import info.freelibrary.iiif.presentation.utils.Constants;
 
@@ -26,6 +27,8 @@ public class Range extends Resource<Range> {
     private ViewingDirection myViewingDirection;
 
     private Optional<URI> myStartCanvas;
+
+    private NavDate myNavDate;
 
     /**
      * Creates a IIIF presentation range.
@@ -67,6 +70,28 @@ public class Range extends Resource<Range> {
     @JsonGetter(Constants.START_CANVAS)
     public Optional<URI> getStartCanvas() {
         return myStartCanvas;
+    }
+
+    /**
+     * Sets a navigation date.
+     *
+     * @param aNavDate The navigation date
+     * @return The range
+     */
+    @JsonSetter(Constants.NAV_DATE)
+    public Range setNavDate(final NavDate aNavDate) {
+        myNavDate = aNavDate;
+        return this;
+    }
+
+    /**
+     * Gets a navigation date.
+     *
+     * @return The navigation date
+     */
+    @JsonGetter(Constants.NAV_DATE)
+    public NavDate getNavDate() {
+        return myNavDate;
     }
 
     /**

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/NavDate.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/NavDate.java
@@ -10,12 +10,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
- * A date that the client can use for navigation purposes when presenting the resource to the user in a time-based
- * user interface, such as a calendar or timeline. The value must be an xsd:dateTime literal in UTC, expressed in the
- * form “YYYY-MM-DDThh:mm:ssZ”. If the exact time is not known, then “00:00:00” should be used. Similarly, the month
- * or day should be 01 if not known. There must be at most one navDate associated with any given resource. More
- * descriptive date ranges, intended for display directly to the user, should be included in the metadata property for
- * human consumption.
+ * A date that clients may use for navigation purposes when presenting the resource to the user in a date-based user
+ * interface, such as a calendar or timeline. More descriptive date ranges, intended for display directly to the user,
+ * should be included in the metadata property for human consumption. If the resource contains Canvases that have the
+ * duration property, the datetime given corresponds to the navigation datetime of the start of the resource. For
+ * example, a Range that includes a Canvas that represents a set of video content recording a historical event, the
+ * navDate is the datetime of the first moment of the recorded event.
  */
 public class NavDate {
 

--- a/src/test/java/info/freelibrary/iiif/presentation/CanvasTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/CanvasTest.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import org.junit.Test;
 
 import info.freelibrary.iiif.presentation.properties.Label;
+import info.freelibrary.iiif.presentation.properties.NavDate;
 
 /**
  * Tests for a presentation canvas.
@@ -40,6 +41,16 @@ public class CanvasTest {
     @Test
     public final void testGetWidth() {
         assertEquals(100, new Canvas(TEST_URI, TEST_LABEL, 100, 100).getWidth());
+    }
+
+    /**
+     * Tests setting and getting a navDate on the canvas.
+     */
+    @Test
+    public final void testNavDate() {
+        final NavDate navDate = NavDate.now();
+
+        assertEquals(navDate, new Canvas(TEST_URI, TEST_LABEL, 100, 100).setNavDate(navDate).getNavDate());
     }
 
     /**

--- a/src/test/java/info/freelibrary/iiif/presentation/RangeTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/RangeTest.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import org.junit.Test;
 
 import info.freelibrary.iiif.presentation.properties.Label;
+import info.freelibrary.iiif.presentation.properties.NavDate;
 import info.freelibrary.iiif.presentation.properties.ViewingDirection;
 
 /**
@@ -33,6 +34,16 @@ public class RangeTest {
     @Test
     public void testRangeURILabel() {
         assertEquals(ID, new Range(ID, new Label(LABEL)).getID());
+    }
+
+    /**
+     * Tests setting and getting a navDate on a range.
+     */
+    @Test
+    public final void testNavDate() {
+        final NavDate navDate = NavDate.now();
+
+        assertEquals(navDate, new Range(ID, new Label(LABEL)).setNavDate(navDate).getNavDate());
     }
 
     /**


### PR DESCRIPTION
NavDate already required a time-zoned datetime, but it needed to be added as options on Canvas and Range.