### PR TITLE
[IIIF-682] Add duration property on Canvas 

### DIFF
--- a/src/main/java/info/freelibrary/iiif/presentation/Canvas.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Canvas.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
@@ -25,7 +26,7 @@ import info.freelibrary.iiif.presentation.utils.MessageCodes;
  * blank canvas and images, text and other resources are &quot;painted&quot; on to it.
  */
 @JsonPropertyOrder({ Constants.TYPE, Constants.LABEL, Constants.ID, Constants.WIDTH, Constants.HEIGHT,
-    Constants.THUMBNAIL, Constants.IMAGE_CONTENT, Constants.OTHER_CONTENT })
+    Constants.DURATION, Constants.THUMBNAIL, Constants.IMAGE_CONTENT, Constants.OTHER_CONTENT })
 public class Canvas extends Resource<Canvas> {
 
     private static final String TYPE = "sc:Canvas";
@@ -35,6 +36,8 @@ public class Canvas extends Resource<Canvas> {
     private int myWidth;
 
     private int myHeight;
+
+    private double myDuration;
 
     private List<ImageContent> myImageContent;
 
@@ -75,6 +78,36 @@ public class Canvas extends Resource<Canvas> {
      * @param aLabel A canvas label
      * @param aWidth A canvas width
      * @param aHeight A canvas height
+     * @param aDuration A canvas duration
+     */
+    public Canvas(final String aID, final String aLabel, final int aWidth, final int aHeight, final double aDuration) {
+        super(TYPE, aID, aLabel, REQ_ARG_COUNT);
+        setWidthHeight(aWidth, aHeight);
+        setDuration(aDuration);
+    }
+
+    /**
+     * Creates a IIIF presentation canvas.
+     *
+     * @param aID A canvas ID
+     * @param aLabel A canvas label
+     * @param aWidth A canvas width
+     * @param aHeight A canvas height
+     * @param aDuration A canvas duration
+     */
+    public Canvas(final URI aID, final Label aLabel, final int aWidth, final int aHeight, final double aDuration) {
+        super(TYPE, aID, aLabel, REQ_ARG_COUNT);
+        setWidthHeight(aWidth, aHeight);
+        setDuration(aDuration);
+    }
+
+    /**
+     * Creates a IIIF presentation canvas.
+     *
+     * @param aID A canvas ID
+     * @param aLabel A canvas label
+     * @param aWidth A canvas width
+     * @param aHeight A canvas height
      * @param aThumbnail A canvas thumbnail
      */
     public Canvas(final String aID, final String aLabel, final int aWidth, final int aHeight,
@@ -98,6 +131,42 @@ public class Canvas extends Resource<Canvas> {
         super(TYPE, aID, aLabel, REQ_ARG_COUNT);
         setWidthHeight(aWidth, aHeight);
         setThumbnail(aThumbnail);
+    }
+
+    /**
+     * Creates a IIIF presentation canvas.
+     *
+     * @param aID A canvas ID
+     * @param aLabel A canvas label
+     * @param aWidth A canvas width
+     * @param aHeight A canvas height
+     * @param aDuration A canvas duration
+     * @param aThumbnail A canvas thumbnail
+     */
+    public Canvas(final String aID, final String aLabel, final int aWidth, final int aHeight, final double aDuration,
+            final Thumbnail aThumbnail) {
+        super(TYPE, aID, aLabel, REQ_ARG_COUNT);
+        setWidthHeight(aWidth, aHeight);
+        setThumbnail(aThumbnail);
+        setDuration(aDuration);
+    }
+
+    /**
+     * Creates a IIIF presentation canvas.
+     *
+     * @param aID A canvas ID
+     * @param aLabel A canvas label
+     * @param aWidth A canvas width
+     * @param aHeight A canvas height
+     * @param aDuration A canvas duration
+     * @param aThumbnail A canvas thumbnail
+     */
+    public Canvas(final URI aID, final Label aLabel, final int aWidth, final int aHeight, final double aDuration,
+            final Thumbnail aThumbnail) {
+        super(TYPE, aID, aLabel, REQ_ARG_COUNT);
+        setWidthHeight(aWidth, aHeight);
+        setThumbnail(aThumbnail);
+        setDuration(aDuration);
     }
 
     /**
@@ -171,6 +240,33 @@ public class Canvas extends Resource<Canvas> {
     @JsonGetter(Constants.NAV_DATE)
     public NavDate getNavDate() {
         return myNavDate;
+    }
+
+    /**
+     * Gets the duration of the canvas.
+     *
+     * @return The duration of the canvas
+     */
+    @JsonGetter(Constants.DURATION)
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public double getDuration() {
+        return myDuration;
+    }
+
+    /**
+     * Sets the duration of the canvas. Duration must be positive and finite.
+     *
+     * @param aDuration A canvas duration
+     * @return The canvas
+     */
+    @JsonSetter(Constants.DURATION)
+    public Canvas setDuration(final double aDuration) {
+        if ((aDuration > 0) && (Double.isFinite(aDuration))) {
+            myDuration = aDuration;
+            return this;
+        } else {
+            throw new IllegalArgumentException(getLogger().getMessage(MessageCodes.JPA_019, aDuration));
+        }
     }
 
     /**

--- a/src/main/java/info/freelibrary/iiif/presentation/utils/Constants.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/utils/Constants.java
@@ -46,6 +46,8 @@ public final class Constants {
 
     public static final String WIDTH = "width";
 
+    public static final String DURATION = "duration";
+
     public static final String HEIGHT = "height";
 
     public static final String SEE_ALSO = "seeAlso";

--- a/src/main/resources/iiif_presentation_messages.xml
+++ b/src/main/resources/iiif_presentation_messages.xml
@@ -22,5 +22,6 @@
   <entry key="JPA-016">Unexpected JSON node: {}</entry>
   <entry key="JPA-017">Illegal viewing direction argument: {}</entry>
   <entry key="JPA-018">Failed to catch illegal viewing direction argument</entry>
+  <entry key="JPA-019">Duration ({}) must be positive and finite</entry>
 
 </properties>

--- a/src/test/java/info/freelibrary/iiif/presentation/CanvasTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/CanvasTest.java
@@ -3,12 +3,16 @@ package info.freelibrary.iiif.presentation;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 
 import org.junit.Test;
 
 import info.freelibrary.iiif.presentation.properties.Label;
 import info.freelibrary.iiif.presentation.properties.NavDate;
+import info.freelibrary.iiif.presentation.utils.TestUtils;
+import info.freelibrary.util.StringUtils;
 
 /**
  * Tests for a presentation canvas.
@@ -19,12 +23,26 @@ public class CanvasTest {
 
     private static final String TEST_LABEL = "My Test Canvas";
 
+    private static final String CANVAS_LABEL_W_H = "canvas-label-width-height.json";
+
+    private static final String CANVAS_LABEL_W_H_D = "canvas-label-width-height-duration.json";
+
+    private Canvas myCanvas;
+
+    private File myCanvasFile;
+
     /**
-     * Tests a canvas constructor.
+     * Tests a canvas constructor and canvas serialization.
+     *
+     * @throws IOException If there is trouble reading the canvas file or serializing the constructed canvas
      */
     @Test
-    public final void testCanvasStringStringIntInt() {
-        assertEquals(TEST_URI, new Canvas(TEST_URI, TEST_LABEL, 100, 100).getID().toString());
+    public final void testCanvasStringStringIntInt() throws IOException {
+        myCanvas = new Canvas(TEST_URI, TEST_LABEL, 100, 100);
+        myCanvasFile = new File(TestUtils.TEST_DIR, CANVAS_LABEL_W_H);
+
+        assertEquals(TEST_URI, myCanvas.getID().toString());
+        assertEquals(StringUtils.read(myCanvasFile), TestUtils.toJson(myCanvas, true));
     }
 
     /**
@@ -33,6 +51,52 @@ public class CanvasTest {
     @Test
     public final void testCanvasURILabelIntInt() {
         assertEquals(TEST_URI, new Canvas(URI.create(TEST_URI), new Label(TEST_LABEL), 200, 200).getID().toString());
+    }
+
+    /**
+     * Tests a canvas constructor and canvas serialization.
+     *
+     * @throws IOException If there is trouble reading the canvas file or serializing the constructed canvas
+     */
+    @Test
+    public final void testCanvasStringStringIntIntDouble() throws IOException {
+        myCanvas = new Canvas(TEST_URI, TEST_LABEL, 100, 100, 60.0d);
+        myCanvasFile = new File(TestUtils.TEST_DIR, CANVAS_LABEL_W_H_D);
+
+        assertEquals(TEST_URI, myCanvas.getID().toString());
+        assertEquals(StringUtils.read(myCanvasFile), TestUtils.toJson(myCanvas, true));
+    }
+
+    /**
+     * Tests a canvas constructor and canvas serialization.
+     *
+     * @throws IOException If there is trouble reading the canvas file or serializing the constructed canvas
+     */
+    @Test
+    public final void testCanvasStringStringIntIntInt() throws IOException {
+        myCanvas = new Canvas(TEST_URI, TEST_LABEL, 100, 100, 60);
+        myCanvasFile = new File(TestUtils.TEST_DIR, CANVAS_LABEL_W_H_D);
+
+        assertEquals(TEST_URI, myCanvas.getID().toString());
+        assertEquals(StringUtils.read(myCanvasFile), TestUtils.toJson(myCanvas, true));
+    }
+
+    /**
+     * Tests a canvas constructor.
+     */
+    @Test
+    public final void testCanvasURILabelIntIntDouble() {
+        myCanvas = new Canvas(URI.create(TEST_URI), new Label(TEST_LABEL), 200, 200, 120.0d);
+        assertEquals(TEST_URI, myCanvas.getID().toString());
+    }
+
+    /**
+     * Tests a canvas constructor.
+     */
+    @Test
+    public final void testCanvasURILabelIntIntInt() {
+        myCanvas = new Canvas(URI.create(TEST_URI), new Label(TEST_LABEL), 200, 200, 120);
+        assertEquals(TEST_URI, myCanvas.getID().toString());
     }
 
     /**
@@ -78,6 +142,24 @@ public class CanvasTest {
     }
 
     /**
+     * Tests getting a canvas' duration.
+     */
+    @Test
+    public final void testGetDuration() {
+        myCanvas = new Canvas(TEST_URI, TEST_LABEL, 100, 100, 60);
+        assertEquals(Double.compare(60.0d, myCanvas.getDuration()), 0);
+    }
+
+    /**
+     * Tests setting a canvas' duration.
+     */
+    @Test
+    public final void testSetDuration() {
+        myCanvas = new Canvas(TEST_URI, TEST_LABEL, 100, 100, 60);
+        assertEquals(Double.compare(120.0d, myCanvas.setDuration(120).getDuration()), 0);
+    }
+
+    /**
      * Tests setting a canvas' width to zero.
      */
     @Test
@@ -94,6 +176,22 @@ public class CanvasTest {
     }
 
     /**
+     * Tests setting a canvas' duration to zero.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public final void testSetZeroDuration() {
+        myCanvas = new Canvas(TEST_URI, TEST_LABEL, 100, 100).setDuration(0);
+    }
+
+    /**
+     * Tests setting a canvas' duration to infinity.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public final void testSetInfiniteDuration() {
+        myCanvas = new Canvas(TEST_URI, TEST_LABEL, 100, 100).setDuration(Double.POSITIVE_INFINITY);
+    }
+
+    /**
      * Tests setting a canvas' width to zero via the constructor.
      */
     @Test
@@ -107,5 +205,21 @@ public class CanvasTest {
     @Test
     public final void testSetZeroHeightInConstructor() {
         assertEquals(0, new Canvas(TEST_URI, TEST_LABEL, 100, 0).getHeight());
+    }
+
+    /**
+     * Tests setting a canvas' duration to zero via the constructor.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public final void testSetZeroDurationInConstructor() {
+        myCanvas = new Canvas(TEST_URI, TEST_LABEL, 100, 100, 0);
+    }
+
+    /**
+     * Tests setting a canvas' duration to infinity via the constructor.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public final void testSetInfiniteDurationInConstructor() {
+        myCanvas = new Canvas(TEST_URI, TEST_LABEL, 100, 100, Double.POSITIVE_INFINITY);
     }
 }

--- a/src/test/java/info/freelibrary/iiif/presentation/CollectionTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/CollectionTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import info.freelibrary.iiif.presentation.properties.Label;
 import info.freelibrary.iiif.presentation.properties.NavDate;
+import info.freelibrary.iiif.presentation.utils.TestUtils;
 import info.freelibrary.util.StringUtils;
 
 import io.vertx.core.Vertx;
@@ -28,7 +29,7 @@ import io.vertx.core.json.JsonObject;
  */
 public class CollectionTest {
 
-    private static final File TEST_FILE1 = new File("src/test/resources/json/collection1.json");
+    private static final File TEST_FILE1 = new File(TestUtils.TEST_DIR, "collection1.json");
 
     private String myID;
 

--- a/src/test/java/info/freelibrary/iiif/presentation/ManifestTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/ManifestTest.java
@@ -3,6 +3,7 @@ package info.freelibrary.iiif.presentation;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.URLDecoder;
@@ -18,6 +19,7 @@ import com.opencsv.CSVReader;
 
 import info.freelibrary.iiif.presentation.properties.Metadata;
 import info.freelibrary.iiif.presentation.services.ImageInfoService;
+import info.freelibrary.iiif.presentation.utils.TestUtils;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -28,7 +30,7 @@ import io.vertx.core.json.JsonObject;
  */
 public class ManifestTest extends AbstractTest {
 
-    private static final String SINAI_JSON = "src/test/resources/json/z1960050.json";
+    private static final String SINAI_JSON = new File(TestUtils.TEST_DIR, "z1960050.json").getAbsolutePath();
 
     private static final String SERVER = "https://sinai-images.library.ucla.edu/iiif/";
 

--- a/src/test/java/info/freelibrary/iiif/presentation/ManifestorTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/ManifestorTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import info.freelibrary.iiif.presentation.io.Manifestor;
+import info.freelibrary.iiif.presentation.utils.TestUtils;
 
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -26,7 +27,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class ManifestorTest {
 
-    private static final File MANIFEST = new File("src/test/resources/json/z1960050.json");
+    private static final File MANIFEST = new File(TestUtils.TEST_DIR, "z1960050.json");
 
     private static final File TMP_DIR = new File(System.getProperty("java.io.tmpdir"));
 

--- a/src/test/java/info/freelibrary/iiif/presentation/examples/Examples.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/examples/Examples.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 
 import info.freelibrary.iiif.presentation.Manifest;
 import info.freelibrary.iiif.presentation.io.Manifestor;
+import info.freelibrary.iiif.presentation.utils.TestUtils;
+import info.freelibrary.util.StringUtils;
 
 /**
  * Examples from documentation.
@@ -22,7 +24,7 @@ public class Examples {
     @Test
     public final void testReadmeExample() throws IOException {
         final Manifestor manifestor = new Manifestor();
-        final Manifest manifest = manifestor.readManifest(new File("src/test/resources/json/z1960050.json"));
+        final Manifest manifest = manifestor.readManifest(new File(TestUtils.TEST_DIR, "z1960050.json"));
 
         manifest.getMetadata().add("Contributor", "Your Name Here");
         manifestor.write(manifest, File.createTempFile("z1960050", ".json"));

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/LogoTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/LogoTest.java
@@ -35,8 +35,6 @@ public class LogoTest {
 
     private static final String LOGO_ADD_IMAGE = "logo-addimage-string-imageinfoservice.json";
 
-    private static final File TEST_DIR = new File("src/test/resources/json");
-
     private static final ImageInfoService SERVICE = new ImageInfoService("http://example.org/asdf");
 
     private static final String MIME_TYPE = "image/jpeg";
@@ -49,7 +47,7 @@ public class LogoTest {
     @Test
     public void testLogoStringArray() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1.toString(), LOGO_ID_2.toString());
-        final File expected = new File(TEST_DIR, LOGO_SIMPLE_2);
+        final File expected = new File(TestUtils.TEST_DIR, LOGO_SIMPLE_2);
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(logo));
     }
@@ -62,7 +60,7 @@ public class LogoTest {
     @Test
     public void testLogoURIArray() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1, LOGO_ID_2);
-        final File expected = new File(TEST_DIR, LOGO_SIMPLE_2);
+        final File expected = new File(TestUtils.TEST_DIR, LOGO_SIMPLE_2);
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(logo));
     }
@@ -75,7 +73,7 @@ public class LogoTest {
     @Test
     public void testLogoStringIntInt() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1.toString(), 1000, 1000);
-        final File expected = new File(TEST_DIR, LOGO_ID_W_H);
+        final File expected = new File(TestUtils.TEST_DIR, LOGO_ID_W_H);
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(logo));
     }
@@ -88,7 +86,7 @@ public class LogoTest {
     @Test
     public void testLogoURIIntInt() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1, 1000, 1000);
-        final File expected = new File(TEST_DIR, LOGO_ID_W_H);
+        final File expected = new File(TestUtils.TEST_DIR, LOGO_ID_W_H);
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(logo));
     }
@@ -101,7 +99,7 @@ public class LogoTest {
     @Test
     public void testLogoStringImageInfoService() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1.toString(), SERVICE);
-        final File expected = new File(TEST_DIR, LOGO_IMAGE_SERVICE);
+        final File expected = new File(TestUtils.TEST_DIR, LOGO_IMAGE_SERVICE);
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(logo, true));
     }
@@ -114,7 +112,7 @@ public class LogoTest {
     @Test
     public void testLogoURIImageInfoService() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1, SERVICE);
-        final File expected = new File(TEST_DIR, LOGO_IMAGE_SERVICE);
+        final File expected = new File(TestUtils.TEST_DIR, LOGO_IMAGE_SERVICE);
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(logo, true));
     }
@@ -127,7 +125,7 @@ public class LogoTest {
     @Test
     public void testAddImageStringIntInt() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1, 1000, 1000);
-        final File expected = new File(TEST_DIR, LOGO_ID_W_H_DOUBLE);
+        final File expected = new File(TestUtils.TEST_DIR, LOGO_ID_W_H_DOUBLE);
 
         logo.addImage(LOGO_ID_2.toString(), 500, 500);
 
@@ -142,7 +140,7 @@ public class LogoTest {
     @Test
     public void testAddImageURIIntInt() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1, 1000, 1000);
-        final File expected = new File(TEST_DIR, LOGO_ID_W_H_DOUBLE);
+        final File expected = new File(TestUtils.TEST_DIR, LOGO_ID_W_H_DOUBLE);
 
         logo.addImage(LOGO_ID_2, 500, 500);
 
@@ -157,7 +155,7 @@ public class LogoTest {
     @Test
     public void testAddImageStringImageInfoService() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1, 1000, 1000);
-        final File expected = new File(TEST_DIR, LOGO_ADD_IMAGE);
+        final File expected = new File(TestUtils.TEST_DIR, LOGO_ADD_IMAGE);
 
         logo.addImage(LOGO_ID_2.toString(), SERVICE);
 
@@ -172,7 +170,7 @@ public class LogoTest {
     @Test
     public void testAddImageURIImageInfoService() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1, 1000, 1000);
-        final File expected = new File(TEST_DIR, LOGO_ADD_IMAGE);
+        final File expected = new File(TestUtils.TEST_DIR, LOGO_ADD_IMAGE);
 
         logo.addImage(LOGO_ID_2, SERVICE);
 
@@ -243,7 +241,7 @@ public class LogoTest {
     @Test
     public void testGetService() throws IOException {
         final Logo logo = new Logo(LOGO_ID_1, SERVICE);
-        final File expected = new File(TEST_DIR, "imageinfoservice.json");
+        final File expected = new File(TestUtils.TEST_DIR, "imageinfoservice.json");
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(logo.getService().get(), true));
     }

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/ThumbnailTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/ThumbnailTest.java
@@ -32,8 +32,6 @@ public class ThumbnailTest {
 
     private static final String TN_FULL_SINGLE = "thumbnail-full-single.json";
 
-    private static final File TEST_DIR = new File("src/test/resources/json");
-
     /**
      * Tests constructing a new thumbnail.
      *
@@ -43,7 +41,7 @@ public class ThumbnailTest {
     @Test
     public void testFullSingleURI() throws JsonProcessingException, IOException {
         final Thumbnail thumbnail = new Thumbnail(THUMBNAIL_ID_1, 1000, 1000);
-        final File expected = new File(TEST_DIR, TN_FULL_SINGLE);
+        final File expected = new File(TestUtils.TEST_DIR, TN_FULL_SINGLE);
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(thumbnail, true));
     }
@@ -57,7 +55,7 @@ public class ThumbnailTest {
     @Test
     public void testFullSingleString() throws JsonProcessingException, IOException {
         final Thumbnail thumbnail = new Thumbnail(THUMBNAIL_ID_1.toString(), 1000, 1000);
-        final File expected = new File(TEST_DIR, TN_FULL_SINGLE);
+        final File expected = new File(TestUtils.TEST_DIR, TN_FULL_SINGLE);
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(thumbnail, true));
     }
@@ -71,7 +69,7 @@ public class ThumbnailTest {
     @Test
     public void testFullSingleService() throws JsonProcessingException, IOException {
         final Thumbnail thumbnail = new Thumbnail(THUMBNAIL_ID_1, new ImageInfoService(PAGE_ID_1));
-        final File expected = new File(TEST_DIR, "thumbnail-full-single-service.json");
+        final File expected = new File(TestUtils.TEST_DIR, "thumbnail-full-single-service.json");
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(thumbnail, true));
     }
@@ -85,7 +83,7 @@ public class ThumbnailTest {
     @Test
     public void testSimpleTwo() throws JsonProcessingException, IOException {
         final Thumbnail thumbnail = new Thumbnail(THUMBNAIL_ID_1, THUMBNAIL_ID_2);
-        final File expected = new File(TEST_DIR, "thumbnail-simple-two.json");
+        final File expected = new File(TestUtils.TEST_DIR, "thumbnail-simple-two.json");
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(thumbnail, false));
     }
@@ -99,7 +97,7 @@ public class ThumbnailTest {
     @Test
     public void testSimpleOne() throws JsonProcessingException, IOException {
         final Thumbnail thumbnail = new Thumbnail(THUMBNAIL_ID_1);
-        final File expected = new File(TEST_DIR, "thumbnail-simple-one.json");
+        final File expected = new File(TestUtils.TEST_DIR, "thumbnail-simple-one.json");
 
         assertEquals(StringUtils.read(expected), TestUtils.toJson(thumbnail, false));
     }

--- a/src/test/java/info/freelibrary/iiif/presentation/utils/TestUtils.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/utils/TestUtils.java
@@ -1,6 +1,8 @@
 
 package info.freelibrary.iiif.presentation.utils;
 
+import java.io.File;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,6 +12,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
  * Utilities for running tests.
  */
 public final class TestUtils {
+
+    public static final String TEST_DIR = "src/test/resources/json";
 
     private TestUtils() {
     }

--- a/src/test/resources/json/canvas-label-width-height-duration.json
+++ b/src/test/resources/json/canvas-label-width-height-duration.json
@@ -1,0 +1,8 @@
+{
+  "type" : "sc:Canvas",
+  "label" : "My Test Canvas",
+  "id" : "http://example.org/iiif/book1/canvas/p1",
+  "width" : 100,
+  "height" : 100,
+  "duration" : 60.0
+}

--- a/src/test/resources/json/canvas-label-width-height.json
+++ b/src/test/resources/json/canvas-label-width-height.json
@@ -1,0 +1,7 @@
+{
+  "type" : "sc:Canvas",
+  "label" : "My Test Canvas",
+  "id" : "http://example.org/iiif/book1/canvas/p1",
+  "width" : 100,
+  "height" : 100
+}


### PR DESCRIPTION
- Small refactor so that (1) `"src/test/resources/json"` occurs only once in the test suite, and (2) `TEST_DIR` is defined only once, in `TestUtils`
- Note that the two new test fixtures do not conform to the 3.0 spec (specifically with `type` and `label`, just like the rest of the fixtures)