### PR TITLE
[IIIF-659] Update Start and add selectors

### DIFF
--- a/src/main/java/info/freelibrary/iiif/presentation/Collection.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Collection.java
@@ -21,7 +21,6 @@ import info.freelibrary.util.I18nRuntimeException;
 
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.json.jackson.DatabindCodec;
 
 /**
  * An ordered list of manifests, and/or further collections. Collections allow easy advertising and browsing of the
@@ -29,11 +28,6 @@ import io.vertx.core.json.jackson.DatabindCodec;
  * clients with a means to locate all of the manifests known to the publishing institution.
  */
 public class Collection extends Resource<Collection> {
-
-    // We initialize this here (in addition to in Manifest) in case someone is using collections without manifests
-    static {
-        DatabindCodec.mapper().findAndRegisterModules();
-    }
 
     private static final String TYPE = "sc:Collection";
 

--- a/src/main/java/info/freelibrary/iiif/presentation/Manifest.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Manifest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -18,6 +19,7 @@ import info.freelibrary.iiif.presentation.properties.Behavior;
 import info.freelibrary.iiif.presentation.properties.Label;
 import info.freelibrary.iiif.presentation.properties.Metadata;
 import info.freelibrary.iiif.presentation.properties.NavDate;
+import info.freelibrary.iiif.presentation.properties.Start;
 import info.freelibrary.iiif.presentation.properties.Summary;
 import info.freelibrary.iiif.presentation.properties.Thumbnail;
 import info.freelibrary.iiif.presentation.properties.ViewingDirection;
@@ -28,7 +30,6 @@ import info.freelibrary.util.I18nRuntimeException;
 
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.json.jackson.DatabindCodec;
 
 /**
  * The overall description of the structure and properties of the digital representation of an object. It carries
@@ -37,11 +38,6 @@ import io.vertx.core.json.jackson.DatabindCodec;
  * present a single object such as a book, a photograph, or a statue.
  */
 public class Manifest extends Resource<Manifest> {
-
-    // We need to find JDK 8+ types for parsing our JSON
-    static {
-        DatabindCodec.mapper().findAndRegisterModules();
-    }
 
     private static final String TYPE = "sc:Manifest";
 
@@ -54,6 +50,8 @@ public class Manifest extends Resource<Manifest> {
     private NavDate myNavDate;
 
     private ViewingDirection myViewingDirection;
+
+    private Optional<Start> myStart = Optional.empty();
 
     /**
      * Creates a IIIF presentation manifest.
@@ -260,6 +258,28 @@ public class Manifest extends Resource<Manifest> {
     public Manifest setSequences(final Sequence... aSequenceArray) {
         mySequences.clear();
         return addSequence(aSequenceArray);
+    }
+
+    /**
+     * Sets the optional start.
+     *
+     * @param aStart A start
+     * @return The range
+     */
+    @JsonSetter(Constants.START)
+    public Manifest setStart(final Start aStart) {
+        myStart = Optional.ofNullable(aStart);
+        return this;
+    }
+
+    /**
+     * Gets the optional start.
+     *
+     * @return The optional start
+     */
+    @JsonGetter(Constants.START)
+    public Optional<Start> getStart() {
+        return myStart;
     }
 
     /**

--- a/src/main/java/info/freelibrary/iiif/presentation/Range.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Range.java
@@ -28,7 +28,7 @@ public class Range extends Resource<Range> {
 
     private ViewingDirection myViewingDirection;
 
-    private Optional<URI> myStartCanvas;
+    private Optional<URI> myStart;
 
     private NavDate myNavDate;
 
@@ -64,25 +64,25 @@ public class Range extends Resource<Range> {
     }
 
     /**
-     * Sets the optional start canvas.
+     * Sets the optional start.
      *
-     * @param aStartCanvas A start canvas
+     * @param aStart A start canvas
      * @return The range
      */
-    @JsonSetter(Constants.START_CANVAS)
-    public Range setStartCanvas(final URI aStartCanvas) {
-        myStartCanvas = Optional.ofNullable(aStartCanvas);
+    @JsonSetter(Constants.START)
+    public Range setStart(final URI aStart) {
+        myStart = Optional.ofNullable(aStart);
         return this;
     }
 
     /**
-     * Gets the optional start canvas.
+     * Gets the optional start.
      *
-     * @return The optional start canvas
+     * @return The optional start
      */
-    @JsonGetter(Constants.START_CANVAS)
-    public Optional<URI> getStartCanvas() {
-        return myStartCanvas;
+    @JsonGetter(Constants.START)
+    public Optional<URI> getStart() {
+        return myStart;
     }
 
     /**

--- a/src/main/java/info/freelibrary/iiif/presentation/Range.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Range.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import info.freelibrary.iiif.presentation.properties.Behavior;
 import info.freelibrary.iiif.presentation.properties.Label;
 import info.freelibrary.iiif.presentation.properties.NavDate;
+import info.freelibrary.iiif.presentation.properties.Start;
 import info.freelibrary.iiif.presentation.properties.ViewingDirection;
 import info.freelibrary.iiif.presentation.properties.behaviors.RangeBehavior;
 import info.freelibrary.iiif.presentation.utils.Constants;
@@ -28,7 +29,7 @@ public class Range extends Resource<Range> {
 
     private ViewingDirection myViewingDirection;
 
-    private Optional<URI> myStart;
+    private Optional<Start> myStart = Optional.empty();
 
     private NavDate myNavDate;
 
@@ -66,11 +67,11 @@ public class Range extends Resource<Range> {
     /**
      * Sets the optional start.
      *
-     * @param aStart A start canvas
+     * @param aStart A start
      * @return The range
      */
     @JsonSetter(Constants.START)
-    public Range setStart(final URI aStart) {
+    public Range setStart(final Start aStart) {
         myStart = Optional.ofNullable(aStart);
         return this;
     }
@@ -81,7 +82,7 @@ public class Range extends Resource<Range> {
      * @return The optional start
      */
     @JsonGetter(Constants.START)
-    public Optional<URI> getStart() {
+    public Optional<Start> getStart() {
         return myStart;
     }
 

--- a/src/main/java/info/freelibrary/iiif/presentation/Resource.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Resource.java
@@ -32,6 +32,8 @@ import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
+import io.vertx.core.json.jackson.DatabindCodec;
+
 /**
  * A resource that can be used as a base for more specific IIIF presentation resources.
  */
@@ -40,6 +42,11 @@ import info.freelibrary.util.LoggerFactory;
     Constants.REQUIRED_STATEMENT, Constants.RIGHTS, Constants.PART_OF, Constants.LOGO, Constants.THUMBNAIL,
     Constants.METADATA, Constants.SEQUENCES, Constants.SERVICE })
 class Resource<T extends Resource<T>> {
+
+    // We initialize this here so it loads for manifests and collections
+    static {
+        DatabindCodec.mapper().findAndRegisterModules();
+    }
 
     @JsonProperty(Constants.TYPE)
     protected final String myType;

--- a/src/main/java/info/freelibrary/iiif/presentation/Sequence.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Sequence.java
@@ -22,7 +22,7 @@ import info.freelibrary.iiif.presentation.utils.Constants;
  * equally valid orders through the content, such as when a manuscript’s pages are rebound or archival collections are
  * reordered.
  */
-@JsonPropertyOrder({ Constants.CONTEXT, Constants.LABEL, Constants.ID, Constants.TYPE, Constants.START_CANVAS,
+@JsonPropertyOrder({ Constants.CONTEXT, Constants.LABEL, Constants.ID, Constants.TYPE, Constants.START,
     Constants.CANVASES })
 public class Sequence extends Resource<Sequence> {
 
@@ -34,7 +34,7 @@ public class Sequence extends Resource<Sequence> {
 
     private final List<Canvas> myCanvases;
 
-    private Optional<URI> myStartCanvas;
+    private Optional<URI> myStart;
 
     /**
      * Creates a IIIF presentation sequence resource.
@@ -65,25 +65,25 @@ public class Sequence extends Resource<Sequence> {
     }
 
     /**
-     * Sets the optional start canvas.
+     * Sets the optional start.
      *
-     * @param aStartCanvas A start canvas
+     * @param aStart A start
      * @return The sequence
      */
-    @JsonSetter(Constants.START_CANVAS)
-    public Sequence setStartCanvas(final URI aStartCanvas) {
-        myStartCanvas = Optional.ofNullable(aStartCanvas);
+    @JsonSetter(Constants.START)
+    public Sequence setStart(final URI aStart) {
+        myStart = Optional.ofNullable(aStart);
         return this;
     }
 
     /**
-     * Gets the optional start canvas.
+     * Gets the optional start.
      *
-     * @return The optional start canvas
+     * @return The optional start
      */
-    @JsonGetter(Constants.START_CANVAS)
-    public Optional<URI> getStartCanvas() {
-        return myStartCanvas;
+    @JsonGetter(Constants.START)
+    public Optional<URI> getStart() {
+        return myStart;
     }
 
     /**

--- a/src/main/java/info/freelibrary/iiif/presentation/Sequence.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Sequence.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -34,8 +33,6 @@ public class Sequence extends Resource<Sequence> {
 
     private final List<Canvas> myCanvases;
 
-    private Optional<URI> myStart;
-
     /**
      * Creates a IIIF presentation sequence resource.
      */
@@ -62,28 +59,6 @@ public class Sequence extends Resource<Sequence> {
         super(TYPE, REQ_ARG_COUNT);
         myCanvases = new ArrayList<>();
         setID(aID);
-    }
-
-    /**
-     * Sets the optional start.
-     *
-     * @param aStart A start
-     * @return The sequence
-     */
-    @JsonSetter(Constants.START)
-    public Sequence setStart(final URI aStart) {
-        myStart = Optional.ofNullable(aStart);
-        return this;
-    }
-
-    /**
-     * Gets the optional start.
-     *
-     * @return The optional start
-     */
-    @JsonGetter(Constants.START)
-    public Optional<URI> getStart() {
-        return myStart;
     }
 
     /**

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/LogoDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/LogoDeserializer.java
@@ -20,7 +20,7 @@ import info.freelibrary.util.LoggerFactory;
 /**
  * A deserializer for the Logo class.
  */
-public class LogoDeserializer extends StdDeserializer {
+class LogoDeserializer extends StdDeserializer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LogoDeserializer.class, Constants.BUNDLE_NAME);
 

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Start.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Start.java
@@ -1,0 +1,168 @@
+
+package info.freelibrary.iiif.presentation.properties;
+
+import java.net.URI;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import info.freelibrary.iiif.presentation.properties.selectors.Selector;
+import info.freelibrary.iiif.presentation.utils.Constants;
+
+/**
+ * A Canvas, or part of a Canvas, which the client should show on initialization for the resource that has the start
+ * property. This property allows the client to begin with the first Canvas that contains interesting content rather
+ * than requiring the user to manually navigate to find it. There are two kinds of Canvas starts: a Canvas start and a
+ * SpecificResource start.
+ */
+@JsonInclude(Include.NON_EMPTY)
+@JsonPropertyOrder({ Constants.TYPE, Constants.ID, Constants.SOURCE, Constants.SELECTOR })
+public class Start {
+
+    public static final String SPECIFIC_RESOURCE = "SpecificResource";
+
+    public static final String CANVAS = "Canvas";
+
+    private URI myID;
+
+    private URI mySource;
+
+    private Selector mySelector;
+
+    /**
+     * Creates a start from the supplied ID in string form.
+     *
+     * @param aID A start ID
+     */
+    public Start(final String aID) {
+        myID = URI.create(aID);
+    }
+
+    /**
+     * Creates a start from the supplied ID.
+     *
+     * @param aID A start ID
+     */
+    public Start(final URI aID) {
+        myID = aID;
+    }
+
+    /**
+     * Sets the start ID in string form.
+     *
+     * @param aID A start ID in string form
+     * @return This start
+     */
+    @JsonProperty(Constants.ID)
+    public Start setID(final String aID) {
+        myID = URI.create(aID);
+        return this;
+    }
+
+    /**
+     * Sets the start ID.
+     *
+     * @param aID The start ID
+     * @return This start
+     */
+    @JsonIgnore
+    public Start setID(final URI aID) {
+        myID = aID;
+        return this;
+    }
+
+    /**
+     * Gets the ID for this start.
+     *
+     * @return This start's ID
+     */
+    @JsonProperty(Constants.ID)
+    public URI getID() {
+        return myID;
+    }
+
+    /**
+     * Gets the type of start: Canvas or SpecifiedResource.
+     *
+     * @return The start type
+     */
+    @JsonProperty(Constants.TYPE)
+    public String getType() {
+        return mySource != null ? SPECIFIC_RESOURCE : CANVAS;
+    }
+
+    /**
+     * Sets the type for this start (in theory). This doesn't actually do anything, though; it's just for Jackson's
+     * deserialization efforts. Type is actually determined by whether the start has a <code>source</code> or just an
+     * <code>ID</code> and <code>type</code>.
+     *
+     * @param aType A start type
+     * @return This start
+     */
+    @JsonProperty(Constants.TYPE)
+    protected Start setType(final String aType) {
+        // Type is set by presence of source, not a passed value
+        return this;
+    }
+
+    /**
+     * Sets the start source in string form.
+     *
+     * @param aSource A source
+     * @return The specific resource start
+     */
+    @JsonProperty(Constants.SOURCE)
+    public Start setSource(final String aSource) {
+        mySource = URI.create(aSource);
+        return this;
+    }
+
+    /**
+     * Sets the start source.
+     *
+     * @param aSource A source
+     * @return The specific resource start
+     */
+    @JsonIgnore
+    public Start setSource(final URI aSource) {
+        mySource = aSource;
+        return this;
+    }
+
+    /**
+     * Gets the start source.
+     *
+     * @return The start source
+     */
+    @JsonProperty(Constants.SOURCE)
+    public Optional<URI> getSource() {
+        return Optional.ofNullable(mySource);
+    }
+
+    /**
+     * Sets a selector.
+     *
+     * @param aSelector A selector
+     * @return This start
+     */
+    @JsonIgnore
+    public Start setSelector(final Selector aSelector) {
+        mySelector = aSelector;
+        return this;
+    }
+
+    /**
+     * Gets an optional selector.
+     *
+     * @return A selector
+     */
+    @JsonProperty(Constants.SELECTOR)
+    public Optional<Selector> getSelector() {
+        return Optional.ofNullable(mySelector);
+    }
+
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/ThumbnailDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/ThumbnailDeserializer.java
@@ -20,7 +20,7 @@ import info.freelibrary.util.LoggerFactory;
 /**
  * A deserializer for the Thumbnail class.
  */
-public class ThumbnailDeserializer extends StdDeserializer {
+class ThumbnailDeserializer extends StdDeserializer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ThumbnailDeserializer.class, Constants.BUNDLE_NAME);
 

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/AbstractSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/AbstractSelector.java
@@ -1,0 +1,29 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import info.freelibrary.iiif.presentation.utils.Constants;
+
+/**
+ * An abstract selector that other selectors can extend.
+ */
+abstract class AbstractSelector implements Selector {
+
+    @Override
+    @JsonProperty(Constants.TYPE)
+    public String getType() {
+        return getClass().getSimpleName();
+    }
+
+    /**
+     * Sets the selector type.
+     *
+     * @param aType A selector type
+     * @return The selector
+     */
+    @JsonProperty(Constants.TYPE)
+    protected AbstractSelector setType(final String aType) {
+        return this;
+    }
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/AudioContentSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/AudioContentSelector.java
@@ -1,0 +1,14 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+/**
+ * An audio content selector used to select the audio from a multi-media stream.
+ */
+public class AudioContentSelector extends AbstractSelector implements ContentSelector {
+
+    @Override
+    public String toString() {
+        return AudioContentSelector.class.getSimpleName();
+    }
+
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/ContentSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/ContentSelector.java
@@ -1,0 +1,12 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+/**
+ * A content selector selects a particular type of content from a resource that has more than one type: for instance,
+ * it might select just the sound from a multi-media stream.
+ */
+public interface ContentSelector extends Selector {
+
+    // Content selectors have a hard-coded type; nothing really needs to be done with them.
+
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/FragmentSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/FragmentSelector.java
@@ -1,0 +1,18 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import java.net.URI;
+
+/**
+ * A fragment selector interface. Particular types of fragment selectors can implement this.
+ */
+public interface FragmentSelector extends Selector {
+
+    /**
+     * Gets which standard to which this fragment selector conforms.
+     *
+     * @return The standard to which this fragment selector conforms
+     */
+    URI getConformsTo();
+
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/ImageApiSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/ImageApiSelector.java
@@ -1,0 +1,203 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.utils.MessageCodes;
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.util.StringUtils;
+
+/**
+ * A selector for IIIF Image APIs.
+ */
+public class ImageApiSelector extends AbstractSelector {
+
+    protected static final String SIZE = "size";
+
+    protected static final String REGION = "region";
+
+    protected static final String ROTATION = "rotation";
+
+    protected static final String QUALITY = "quality";
+
+    protected static final String FORMAT = "format";
+
+    protected static final String DEFAULT_SIZE = "max";
+
+    protected static final String DEFAULT_REGION = "full";
+
+    protected static final String DEFAULT_ROTATION = "0";
+
+    protected static final String DEFAULT_QUALITY = "default";
+
+    protected static final String DEFAULT_FORMAT = "jpg";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageApiSelector.class, Constants.BUNDLE_NAME);
+
+    private static final String SLASH = "/";
+
+    private String myRegion = DEFAULT_REGION;
+
+    private String mySize = DEFAULT_SIZE;
+
+    private String myRotation = DEFAULT_ROTATION;
+
+    private String myQuality = DEFAULT_QUALITY;
+
+    private String myFormat = DEFAULT_FORMAT;
+
+    /**
+     * Creates an Image API selector.
+     */
+    public ImageApiSelector() {
+    }
+
+    /**
+     * Creates an Image API selector.
+     *
+     * @param aRegion A region from an image
+     * @param aSize A size from an image
+     * @param aRotation A rotation from an image
+     * @param aQuality A quality of an image
+     * @param aFormat A format of an image
+     */
+    public ImageApiSelector(final String aRegion, final String aSize, final String aRotation, final String aQuality,
+            final String aFormat) {
+        myRegion = aRegion;
+        mySize = aSize;
+        myRotation = aRotation;
+        myQuality = aQuality;
+        myFormat = aFormat;
+    }
+
+    /**
+     * Creates an Image API selector from the supplied API path.
+     *
+     * @param aUrlPath An Image API URL path
+     * @throws IllegalArgumentException If the supplied URL path isn't a valid IIIF Image API URL
+     */
+    public ImageApiSelector(final String aUrlPath) {
+        final String[] parts = aUrlPath.indexOf('/') == 0 ? aUrlPath.substring(1).split(SLASH) : aUrlPath.split(
+                SLASH);
+        final int dotIndex;
+
+        if (parts.length != 4) {
+            throw new IllegalArgumentException(LOGGER.getMessage(MessageCodes.JPA_036, aUrlPath));
+        }
+
+        if ((dotIndex = parts[3].indexOf('.')) == -1) {
+            throw new IllegalArgumentException(LOGGER.getMessage(MessageCodes.JPA_035, aUrlPath));
+        }
+
+        myRegion = parts[0];
+        mySize = parts[1];
+        myRotation = parts[2];
+        myQuality = parts[3].substring(0, dotIndex);
+        myFormat = parts[3].substring(dotIndex + 1);
+    }
+
+    /**
+     * Gets the requested region.
+     *
+     * @return The requested region
+     */
+    public String getRegion() {
+        return myRegion;
+    }
+
+    /**
+     * Sets the requested region.
+     *
+     * @param aRegion A region to set
+     * @return This image API selector
+     */
+    public ImageApiSelector setRegion(final String aRegion) {
+        myRegion = aRegion;
+        return this;
+    }
+
+    /**
+     * Gets the requested size.
+     *
+     * @return The requested size
+     */
+    public String getSize() {
+        return mySize;
+    }
+
+    /**
+     * Sets the requested size.
+     *
+     * @param aSize A size to set
+     * @return This image API selector
+     */
+    public ImageApiSelector setSize(final String aSize) {
+        mySize = aSize;
+        return this;
+    }
+
+    /**
+     * Gets the requested rotation.
+     *
+     * @return The requested rotation
+     */
+    public String getRotation() {
+        return myRotation;
+    }
+
+    /**
+     * Sets the requested rotation.
+     *
+     * @param aRotation A rotation to set
+     * @return This image API selector
+     */
+    public ImageApiSelector setRotation(final String aRotation) {
+        myRotation = aRotation;
+        return this;
+    }
+
+    /**
+     * Gets the requested image quality.
+     *
+     * @return The requested image quality
+     */
+    public String getQuality() {
+        return myQuality;
+    }
+
+    /**
+     * Sets the image quality.
+     *
+     * @param aQuality An image quality to set
+     * @return This image API selector
+     */
+    public ImageApiSelector setQuality(final String aQuality) {
+        myQuality = aQuality;
+        return this;
+    }
+
+    /**
+     * Gets the image format.
+     *
+     * @return The image format
+     */
+    public String getFormat() {
+        return myFormat;
+    }
+
+    /**
+     * Sets the image format.
+     *
+     * @param aFormat The image format to set
+     * @return This image API selector
+     */
+    public ImageApiSelector setFormat(final String aFormat) {
+        myFormat = aFormat;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return StringUtils.format("/{}/{}/{}/{}.{}", myRegion, mySize, myRotation, myQuality, myFormat);
+    }
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/MediaFragmentSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/MediaFragmentSelector.java
@@ -1,0 +1,152 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import java.net.URI;
+
+import info.freelibrary.util.StringUtils;
+
+/**
+ * A fragment selector selects regions of interest in a resource.
+ */
+public class MediaFragmentSelector extends AbstractSelector implements FragmentSelector {
+
+    protected static final String X_COORDINATE = "x";
+
+    protected static final String Y_COORDINATE = "y";
+
+    // https://www.w3.org/TR/annotation-model/#fragment-selector
+    private static final URI FRAGMENT_STANDARD = URI.create("http://www.w3.org/TR/media-frags/");
+
+    private int myX;
+
+    private int myY;
+
+    private int myWidth;
+
+    private int myHeight;
+
+    /**
+     * Creates a fragment selector from the supplied string of comma delimited integers.
+     *
+     * @param aFragment A fragment representation in string form
+     * @throws IllegalArgumentException If the supplied string isn't a valid fragment representation
+     */
+    public MediaFragmentSelector(final String aFragment) throws IllegalArgumentException {
+        final String[] parts = aFragment.split(",");
+
+        // A fragment has four coordinates: x, y, width, and height
+        if (parts.length != 4) {
+            throw new IllegalArgumentException();
+        }
+
+        myX = Integer.parseInt(parts[0]);
+        myY = Integer.parseInt(parts[1]);
+        myWidth = Integer.parseInt(parts[2]);
+        myHeight = Integer.parseInt(parts[3]);
+    }
+
+    /**
+     * Creates a fragment selector from the supplied coordinates.
+     *
+     * @param aX An X position
+     * @param aY A Y position
+     * @param aWidth A width
+     * @param aHeight A height
+     */
+    public MediaFragmentSelector(final int aX, final int aY, final int aWidth, final int aHeight) {
+        myX = aX;
+        myY = aY;
+        myWidth = aWidth;
+        myHeight = aHeight;
+    }
+
+    /**
+     * Gets the X coordinate.
+     *
+     * @return The X coordinate
+     */
+    public int getX() {
+        return myX;
+    }
+
+    /**
+     * Sets the X coordinate.
+     *
+     * @param aX An X coordinate
+     * @return The fragment selector
+     */
+    public MediaFragmentSelector setX(final int aX) {
+        myX = aX;
+        return this;
+    }
+
+    /**
+     * Gets the Y coordinate.
+     *
+     * @return The Y coordinate
+     */
+    public int getY() {
+        return myY;
+    }
+
+    /**
+     * Sets the Y coordinate.
+     *
+     * @param aY A Y coordinate
+     * @return The fragment selector
+     */
+    public MediaFragmentSelector setY(final int aY) {
+        myY = aY;
+        return this;
+    }
+
+    /**
+     * Gets the width.
+     *
+     * @return The width
+     */
+    public int getWidth() {
+        return myWidth;
+    }
+
+    /**
+     * Sets the width.
+     *
+     * @param aWidth A width
+     * @return The fragment selector
+     */
+    public MediaFragmentSelector setWidth(final int aWidth) {
+        myWidth = aWidth;
+        return this;
+    }
+
+    /**
+     * Gets the height.
+     *
+     * @return The height
+     */
+    public int getHeight() {
+        return myHeight;
+    }
+
+    /**
+     * Sets the height.
+     *
+     * @param aHeight A height
+     * @return The fragment selector
+     */
+    public MediaFragmentSelector setHeight(final int aHeight) {
+        myHeight = aHeight;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return StringUtils.format("{},{},{},{}", myX, myY, myWidth, myHeight);
+    }
+
+    @Override
+    public URI getConformsTo() {
+        return FRAGMENT_STANDARD;
+    }
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/PointSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/PointSelector.java
@@ -1,0 +1,162 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A selector that selects an individual point in a target resource.
+ */
+@JsonInclude(Include.NON_NULL)
+public class PointSelector extends AbstractSelector {
+
+    protected static final String X_COORDINATE = "x";
+
+    protected static final String Y_COORDINATE = "y";
+
+    protected static final String T_COORDINATE = "t";
+
+    /* An integer giving the x coordinate of the point, relative to the dimensions of the target resource. */
+    private OptionalInt myX;
+
+    /* An integer giving the y coordinate of the point, relative to the dimensions of the target resource. */
+    private OptionalInt myY;
+
+    /* A floating point giving the time of the point in seconds, relative to the duration of the target resource. */
+    private Optional<Float> myT;
+
+    /**
+     * Creates a point selector from X and Y coordinates.
+     *
+     * @param aX An X coordinate
+     * @param aY A Y coordinate
+     */
+    public PointSelector(final int aX, final int aY) {
+        setX(aX);
+        setY(aY);
+    }
+
+    /**
+     * Creates a point selector from X, Y, and time (T) coordinates.
+     *
+     * @param aX An X coordinate
+     * @param aY A Y coordinate
+     * @param aSecondsCount A time coordinate
+     */
+    public PointSelector(final int aX, final int aY, final float aSecondsCount) {
+        setX(aX);
+        setY(aY);
+        setSeconds(aSecondsCount);
+    }
+
+    /**
+     * Creates a point selector from X, Y, and time (T) coordinates.
+     *
+     * @param aX An X coordinate
+     * @param aY A Y coordinate
+     * @param aMinutesCount A time coordinate
+     */
+    public PointSelector(final int aX, final int aY, final long aMinutesCount) {
+        setX(aX);
+        setY(aY);
+        setMinutes(aMinutesCount);
+    }
+
+    /**
+     * Creates a point selector for a temporal point (measured in seconds from the start of the target resource).
+     *
+     * @param aSecondsCount A number of seconds since the start of the resource
+     */
+    public PointSelector(final float aSecondsCount) {
+        setSeconds(aSecondsCount);
+    }
+
+    /**
+     * Creates a point selector for a temporal point (measured in minutes from the start of the target resource).
+     *
+     * @param aMinutesCount A number of minutes since the start of the resource
+     */
+    public PointSelector(final long aMinutesCount) {
+        setMinutes(aMinutesCount);
+    }
+
+    /**
+     * Sets the X coordinate for the selector.
+     *
+     * @param aX An X coordinate
+     * @return This point selector
+     */
+    public PointSelector setX(final int aX) {
+        myX = OptionalInt.of(aX);
+        return this;
+    }
+
+    /**
+     * Gets the X coordinate for the selector.
+     *
+     * @return The X coordinate
+     */
+    public OptionalInt getX() {
+        return myX;
+    }
+
+    /**
+     * Sets the Y coordinate for the selector.
+     *
+     * @param aY An Y coordinate
+     * @return This point selector
+     */
+    public PointSelector setY(final int aY) {
+        myY = OptionalInt.of(aY);
+        return this;
+    }
+
+    /**
+     * Gets the Y coordinate for the selector.
+     *
+     * @return The Y coordinate
+     */
+    public OptionalInt getY() {
+        return myY;
+    }
+
+    /**
+     * Sets the time coordinate for the selector.
+     *
+     * @param aSecondsCount A number of seconds since the start of the resource
+     * @return This point selector
+     */
+    @JsonProperty(PointSelector.T_COORDINATE)
+    public PointSelector setSeconds(final Float aSecondsCount) {
+        myT = Optional.of(Float.valueOf(aSecondsCount));
+        return this;
+    }
+
+    /**
+     * Sets the time coordinate for the selector in minutes.
+     *
+     * @param aMinutesCount A number of minutes since the start of the resource
+     * @return This point selector
+     */
+    @JsonIgnore
+    public PointSelector setMinutes(final long aMinutesCount) {
+        myT = Optional.of(Float.valueOf(TimeUnit.MINUTES.toSeconds(aMinutesCount)));
+        return this;
+    }
+
+    /**
+     * Gets the time coordinate for the selector.
+     *
+     * @return The number of seconds since the start of the resource
+     */
+    @JsonProperty(PointSelector.T_COORDINATE)
+    public Optional<Float> getSeconds() {
+        return myT;
+    }
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/Selector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/Selector.java
@@ -1,0 +1,19 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * A selector that can select a particular portion of a resource.
+ */
+@JsonDeserialize(using = SelectorDeserializer.class)
+public interface Selector {
+
+    /**
+     * Gets the type of selector.
+     *
+     * @return The selector type
+     */
+    String getType();
+
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/SelectorDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/SelectorDeserializer.java
@@ -1,0 +1,142 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import info.freelibrary.iiif.presentation.utils.Constants;
+
+/**
+ * A deserializer for classes that implement the Selector interface.
+ */
+public class SelectorDeserializer extends StdDeserializer<Selector> {
+
+    /**
+     * The <code>serialVersionUID</code> for SelectorDeserializer.
+     */
+    private static final long serialVersionUID = 505267696639975498L;
+
+    /**
+     * Creates a new deserializer.
+     */
+    public SelectorDeserializer() {
+        this(null);
+    }
+
+    /**
+     * Creates a new deserializer.
+     *
+     * @param aClass A class
+     */
+    SelectorDeserializer(final Class<?> aClass) {
+        super(aClass);
+    }
+
+    @Override
+    public Selector deserialize(final JsonParser aParser, final DeserializationContext aContext) throws IOException,
+            JsonProcessingException {
+        final JsonNode node = aParser.getCodec().readTree(aParser);
+        final JsonNode typeNode = node.get(Constants.TYPE);
+
+        if (typeNode != null) {
+            switch (typeNode.asText()) {
+                case "AudioContentSelector":
+                    return new AudioContentSelector();
+                case "VisualContentSelector":
+                    return new VisualContentSelector();
+                case "MediaFragmentSelector":
+                    final int x = node.get(MediaFragmentSelector.X_COORDINATE).asInt();
+                    final int y = node.get(MediaFragmentSelector.Y_COORDINATE).asInt();
+                    final int width = node.get(Constants.WIDTH).asInt();
+                    final int height = node.get(Constants.HEIGHT).asInt();
+
+                    return new MediaFragmentSelector(x, y, width, height);
+                case "ImageApiSelector":
+                    final String size = getText(node, ImageApiSelector.SIZE, ImageApiSelector.DEFAULT_SIZE);
+                    final String region = getText(node, ImageApiSelector.REGION, ImageApiSelector.DEFAULT_REGION);
+                    final String format = getText(node, ImageApiSelector.FORMAT, ImageApiSelector.DEFAULT_FORMAT);
+                    final String quality = getText(node, ImageApiSelector.QUALITY, ImageApiSelector.DEFAULT_QUALITY);
+                    final String rotation = getText(node, ImageApiSelector.ROTATION,
+                            ImageApiSelector.DEFAULT_ROTATION);
+
+                    return new ImageApiSelector(region, size, rotation, quality, format);
+                case "PointSelector":
+                    final int pointX = getInt(node, PointSelector.X_COORDINATE, -1);
+                    final int pointY = getInt(node, PointSelector.Y_COORDINATE, -1);
+                    final float pointT = getFloat(node, PointSelector.T_COORDINATE, -1F);
+
+                    // We could play this looser and rely on the class, but let's be explicit w/r/t what we expect
+                    if (pointX == -1 && pointY == -1 && pointT != -1F) {
+                        return new PointSelector(pointT);
+                    } else if (pointX != -1 && pointY != -1 && pointT == -1F) {
+                        return new PointSelector(pointX, pointY);
+                    } else if (pointX != -1 && pointY != -1 && pointT != -1F) {
+                        return new PointSelector(pointX, pointY, pointT);
+                    } // else, return null (no break needed)
+                default:
+                    // Checkstyle wants us to have a default; it falls through to return null
+            }
+        }
+
+        return null; // Return nothing (which will be ignored) versus throwing an exception?
+    }
+
+    /**
+     * Gets an integer from a node that may or may not exist in the JSON.
+     *
+     * @param aNode A parent node
+     * @param aNodeName The name of an optional child node
+     * @param aDefaultValue The default string value for missing nodes
+     * @return The text from the node or the default value
+     */
+    private int getInt(final JsonNode aNode, final String aNodeName, final int aDefaultValue) {
+        final JsonNode node = aNode.get(aNodeName);
+
+        if (node == null) {
+            return aDefaultValue;
+        } else {
+            return node.asInt(aDefaultValue);
+        }
+    }
+
+    /**
+     * Gets a float from a node that may or may not exist in the JSON.
+     *
+     * @param aNode A parent node
+     * @param aNodeName The name of an optional child node
+     * @param aDefaultValue The default string value for missing nodes
+     * @return The text from the node or the default value
+     */
+    private float getFloat(final JsonNode aNode, final String aNodeName, final float aDefaultValue) {
+        final JsonNode node = aNode.get(aNodeName);
+
+        if (node == null) {
+            return aDefaultValue;
+        } else {
+            return node.floatValue();
+        }
+    }
+
+    /**
+     * Gets the text from a node that may or may not exist in the JSON.
+     *
+     * @param aNode A parent node
+     * @param aNodeName The name of an optional child node
+     * @param aDefaultValue The default string value for missing nodes
+     * @return The text from the node or the default value
+     */
+    private String getText(final JsonNode aNode, final String aNodeName, final String aDefaultValue) {
+        final JsonNode node = aNode.get(aNodeName);
+
+        if (node == null) {
+            return aDefaultValue;
+        } else {
+            return node.asText(aDefaultValue);
+        }
+    }
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/VisualContentSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/VisualContentSelector.java
@@ -1,0 +1,14 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+/**
+ * A visual content selector used to select the visual content from a multi-media stream.
+ */
+public class VisualContentSelector extends AbstractSelector implements ContentSelector {
+
+    @Override
+    public String toString() {
+        return VisualContentSelector.class.getSimpleName();
+    }
+
+}

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/package-info.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Classes for working with different types of selectors.
+ */
+
+package info.freelibrary.iiif.presentation.properties.selectors;

--- a/src/main/java/info/freelibrary/iiif/presentation/utils/Constants.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/utils/Constants.java
@@ -75,6 +75,10 @@ public final class Constants {
 
     public static final String ON = "on";
 
+    public static final String SOURCE = "source";
+
+    public static final String SELECTOR = "selector";
+
     public static final String RESOURCE = "resource";
 
     public static final String RESOURCES = "resources";
@@ -95,7 +99,7 @@ public final class Constants {
 
     public static final String PHYSICAL_UNITS = "physicalUnits";
 
-    public static final String START_CANVAS = "startCanvas";
+    public static final String START = "start";
 
     private Constants() {
         super();

--- a/src/main/resources/iiif_presentation_messages.xml
+++ b/src/main/resources/iiif_presentation_messages.xml
@@ -38,5 +38,7 @@
   <entry key="JPA-032">Supplied HTML text must have a single root element: {}</entry>
   <entry key="JPA-033">Stripping disallowed HTML markup in following string: {}</entry>
   <entry key="JPA-034">Supplied entry was a {} entry not a {} entry</entry>
+  <entry key="JPA-035">IIIF Image API URL does not have a dot before format: {}</entry>
+  <entry key="JPA-036">IIIF Image API URL does not have the correct number of components: {}</entry>
 
 </properties>

--- a/src/test/java/info/freelibrary/iiif/presentation/AbstractTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/AbstractTest.java
@@ -3,7 +3,7 @@ package info.freelibrary.iiif.presentation;
 
 import org.junit.BeforeClass;
 
-import io.vertx.core.json.Json;
+import io.vertx.core.json.jackson.DatabindCodec;
 
 /**
  * An abstract test.
@@ -21,7 +21,7 @@ public class AbstractTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         // We need to register jackson-databind-jdk8 module, among possible others
-        Json.mapper.findAndRegisterModules();
+        DatabindCodec.mapper().findAndRegisterModules();
     }
 
 }

--- a/src/test/java/info/freelibrary/iiif/presentation/SequenceTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/SequenceTest.java
@@ -38,11 +38,6 @@ public class SequenceTest {
     }
 
     @Test
-    public final void testSetStart() {
-        assertEquals(URI.create(myID), new Sequence().setStart(URI.create(myID)).getStart().get());
-    }
-
-    @Test
     public final void testSetViewingDirection() {
         assertEquals(ViewingDirection.LEFT_TO_RIGHT, new Sequence().setViewingDirection(
                 ViewingDirection.LEFT_TO_RIGHT).getViewingDirection());

--- a/src/test/java/info/freelibrary/iiif/presentation/SequenceTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/SequenceTest.java
@@ -38,8 +38,8 @@ public class SequenceTest {
     }
 
     @Test
-    public final void testSetStartCanvas() {
-        assertEquals(URI.create(myID), new Sequence().setStartCanvas(URI.create(myID)).getStartCanvas().get());
+    public final void testSetStart() {
+        assertEquals(URI.create(myID), new Sequence().setStart(URI.create(myID)).getStart().get());
     }
 
     @Test

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/StartTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/StartTest.java
@@ -1,0 +1,60 @@
+
+package info.freelibrary.iiif.presentation.properties;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.thedeanda.lorem.Lorem;
+import com.thedeanda.lorem.LoremIpsum;
+
+import info.freelibrary.iiif.presentation.AbstractTest;
+import info.freelibrary.iiif.presentation.properties.selectors.AudioContentSelector;
+import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.util.StringUtils;
+
+import io.vertx.core.json.JsonObject;
+
+public class StartTest extends AbstractTest {
+
+    private static final String CANVAS_PATTERN = "{\"type\":\"Canvas\",\"id\":\"{}\"}";
+
+    // Might be neat to create a IIIF LoremIpsum at some point
+    private final Lorem myLorem = LoremIpsum.getInstance();
+
+    /**
+     * Tests the canvas start.
+     */
+    @Test
+    public final void testCanvasStart() {
+        final String url = myLorem.getUrl();
+        final String json = StringUtils.format(CANVAS_PATTERN, url);
+
+        assertEquals(json, JsonObject.mapFrom(new Start(url)).encode());
+    }
+
+    /**
+     * Tests the specific resources start.
+     */
+    @Test
+    public final void testSpecificResourceStart() {
+        final JsonObject json = new JsonObject();
+        final String idURL = myLorem.getUrl();
+        final String sourceURL = myLorem.getUrl();
+
+        json.put(Constants.TYPE, Start.SPECIFIC_RESOURCE).put(Constants.ID, idURL).put(Constants.SOURCE, sourceURL);
+
+        assertEquals(json, JsonObject.mapFrom(new Start(idURL).setSource(sourceURL)));
+    }
+
+    /**
+     * Tests setting the selector.
+     */
+    @Test
+    public final void testSettingSelector() {
+        final AudioContentSelector selector = new AudioContentSelector();
+        final Start start = new Start(myLorem.getUrl()).setSelector(selector);
+
+        assertEquals(selector, start.getSelector().get());
+    }
+}

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/AudioContentSelectorTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/AudioContentSelectorTest.java
@@ -1,0 +1,30 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests of the audio content selector.
+ */
+public class AudioContentSelectorTest {
+
+    private static final String SELECTOR_NAME = "AudioContentSelector";
+
+    /**
+     * Tests the <code>getType()</code> method of AudioContentSelector.
+     */
+    @Test
+    public final void testGetType() {
+        assertEquals(SELECTOR_NAME, new AudioContentSelector().getType());
+    }
+
+    /**
+     * Tests the <code>toString()</code> method of AudioContentSelector.
+     */
+    @Test
+    public final void testToString() {
+        assertEquals(SELECTOR_NAME, new AudioContentSelector().toString());
+    }
+}

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/ImageApiSelectorTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/ImageApiSelectorTest.java
@@ -1,0 +1,100 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests of the ImageApiSelector.
+ */
+public class ImageApiSelectorTest {
+
+    private static final String PATH = "/pct:0,0,10,10/pct:90/90/gray.png";
+
+    private static final String FULL = "full";
+
+    private static final String MAX = "max";
+
+    private static final String ZERO = "0";
+
+    private static final String DEFAULT = "default";
+
+    private static final String JPG = "jpg";
+
+    /**
+     * Tests the full constructor.
+     */
+    @Test
+    public void testFullConstructor() {
+        final ImageApiSelector selector = new ImageApiSelector(FULL, MAX, ZERO, DEFAULT, JPG);
+
+        assertEquals(FULL, selector.getRegion());
+        assertEquals(MAX, selector.getSize());
+        assertEquals(ZERO, selector.getRotation());
+        assertEquals(DEFAULT, selector.getQuality());
+        assertEquals(JPG, selector.getFormat());
+    }
+
+    /**
+     * Tests the path constructor.
+     */
+    @Test
+    public void testPathConstructor() {
+        final ImageApiSelector selector = new ImageApiSelector("/full/full/0/default.jpg");
+
+        assertEquals(FULL, selector.getRegion());
+        assertEquals(FULL, selector.getSize());
+        assertEquals(ZERO, selector.getRotation());
+        assertEquals(DEFAULT, selector.getQuality());
+        assertEquals(JPG, selector.getFormat());
+    }
+
+    /**
+     * Tests setting the region.
+     */
+    @Test
+    public void testSetRegion() {
+        assertEquals(FULL, new ImageApiSelector(PATH).setRegion(FULL).getRegion());
+    }
+
+    /**
+     * Tests setting the size.
+     */
+    @Test
+    public void testSetSize() {
+        assertEquals(FULL, new ImageApiSelector(PATH).setSize(FULL).getSize());
+    }
+
+    /**
+     * Tests setting the rotation.
+     */
+    @Test
+    public void testSetRotation() {
+        assertEquals(ZERO, new ImageApiSelector(PATH).setRotation(ZERO).getRotation());
+    }
+
+    /**
+     * Tests setting the quality.
+     */
+    @Test
+    public void testSetQuality() {
+        assertEquals(DEFAULT, new ImageApiSelector(PATH).setQuality(DEFAULT).getQuality());
+    }
+
+    /**
+     * Tests setting the format.
+     */
+    @Test
+    public void testSetFormat() {
+        assertEquals(JPG, new ImageApiSelector(PATH).setFormat(JPG).getFormat());
+    }
+
+    /**
+     * Tests the <code>toString()</code> method.
+     */
+    @Test
+    public void testToString() {
+        assertEquals("/full/max/0/default.jpg", new ImageApiSelector().toString());
+    }
+}

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/MediaFragmentSelectorTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/MediaFragmentSelectorTest.java
@@ -1,0 +1,91 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+/**
+ * Tests of the fragment selector.
+ */
+public class MediaFragmentSelectorTest {
+
+    // https://www.w3.org/TR/annotation-model/#fragment-selector
+    private static final URI FRAGMENT_STANDARD = URI.create("http://www.w3.org/TR/media-frags/");
+
+    /**
+     * Tests the fragment selector's string constructor.
+     */
+    @Test
+    public final void testConstructorString() {
+        final MediaFragmentSelector selector = new MediaFragmentSelector("0,1,750,300");
+
+        assertEquals(0, selector.getX());
+        assertEquals(1, selector.getY());
+        assertEquals(750, selector.getWidth());
+        assertEquals(300, selector.getHeight());
+    }
+
+    /**
+     * Tests the fragment selector's integer constructor.
+     */
+    @Test
+    public final void testConstructorInts() {
+        final MediaFragmentSelector selector = new MediaFragmentSelector(0, 1, 750, 300);
+
+        assertEquals(0, selector.getX());
+        assertEquals(1, selector.getY());
+        assertEquals(750, selector.getWidth());
+        assertEquals(300, selector.getHeight());
+    }
+
+    /**
+     * Tests setting X in the fragment selector.
+     */
+    @Test
+    public final void testSettingX() {
+        assertEquals(100, new MediaFragmentSelector(0, 1, 750, 300).setX(100).getX());
+    }
+
+    /**
+     * Tests setting Y in the fragment selector.
+     */
+    @Test
+    public final void testSettingY() {
+        assertEquals(100, new MediaFragmentSelector(0, 1, 750, 300).setY(100).getY());
+    }
+
+    /**
+     * Tests setting width in the fragment selector.
+     */
+    @Test
+    public final void testSettingWidth() {
+        assertEquals(100, new MediaFragmentSelector(0, 1, 750, 300).setWidth(100).getWidth());
+    }
+
+    /**
+     * Tests setting height in the fragment selector.
+     */
+    @Test
+    public final void testSettingHeight() {
+        assertEquals(100, new MediaFragmentSelector(0, 1, 750, 300).setHeight(100).getHeight());
+    }
+
+    /**
+     * Tests the <code>toString()</code> method.
+     */
+    @Test
+    public final void testToString() {
+        assertEquals("0,0,750,300", new MediaFragmentSelector(0, 0, 750, 300).toString());
+    }
+
+    /**
+     * Test the <code>conformsTo()</code> method.
+     */
+    @Test
+    public final void testConformsTo() {
+        assertEquals(FRAGMENT_STANDARD, new MediaFragmentSelector(0, 0, 750, 300).getConformsTo());
+    }
+}

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/PointSelectorTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/PointSelectorTest.java
@@ -1,0 +1,101 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import info.freelibrary.iiif.presentation.AbstractTest;
+import info.freelibrary.iiif.presentation.utils.Constants;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests related to the PointSelector.
+ */
+public class PointSelectorTest extends AbstractTest {
+
+    /**
+     * Tests the X and Y coordinate constructor.
+     */
+    @Test
+    public final void testXYCoordinateConstructor() {
+        final PointSelector selector = new PointSelector(0, 10);
+
+        assertEquals(0, selector.getX().getAsInt());
+        assertEquals(10, selector.getY().getAsInt());
+    }
+
+    /**
+     * Tests the X, Y, and time (T) coordinate constructor.
+     */
+    @Test
+    public final void testXYTCoordinateConstructor() {
+        final PointSelector selector = new PointSelector(0, 10, 1.5F);
+
+        assertEquals(0, selector.getX().getAsInt());
+        assertEquals(10, selector.getY().getAsInt());
+        assertEquals(Float.valueOf(1.5F), selector.getSeconds().get());
+    }
+
+    /**
+     * Tests <code>setX()</code> method.
+     */
+    @Test
+    public final void testSettingX() {
+        assertEquals(10, new PointSelector(10F).setX(10).getX().getAsInt());
+    }
+
+    /**
+     * Tests <code>setY()</code> method.
+     */
+    @Test
+    public final void testSettingY() {
+        assertEquals(10, new PointSelector(10F).setY(10).getY().getAsInt());
+    }
+
+    /**
+     * Tests the time (in seconds) constructor.
+     */
+    @Test
+    public final void testTimeConstructorInSeconds() {
+        assertEquals(Float.valueOf(10F), new PointSelector(10F).getSeconds().get());
+    }
+
+    /**
+     * Test the time (in seconds) constructor.
+     */
+    @Test
+    public final void testSettingTimeInSeconds() {
+        assertEquals(Float.valueOf(10F), new PointSelector(2F).setSeconds(10F).getSeconds().get());
+    }
+
+    /**
+     * Tests the time (in minutes) constructor.
+     */
+    @Test
+    public final void testTimeConstructorInMinutes() {
+        assertEquals(Float.valueOf(300F), new PointSelector(5L).getSeconds().get());
+    }
+
+    /**
+     * Test the time (in minutes) constructor.
+     */
+    @Test
+    public final void testSettingTimeInMinutes() {
+        assertEquals(Float.valueOf(300F), new PointSelector(2F).setMinutes(5L).getSeconds().get());
+    }
+
+    /**
+     * Tests the JSON serialization is what we expect (e.g., nulls are ignored).
+     */
+    @Test
+    public final void testSerialization() {
+        final JsonObject found = JsonObject.mapFrom(new PointSelector(10F));
+        final JsonObject expected = new JsonObject();
+
+        expected.put(PointSelector.T_COORDINATE, 10.0F).put(Constants.TYPE, PointSelector.class.getSimpleName());
+
+        assertEquals(expected, found);
+    }
+}

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/SelectorDeserializerTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/SelectorDeserializerTest.java
@@ -1,0 +1,87 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import info.freelibrary.iiif.presentation.AbstractTest;
+import info.freelibrary.iiif.presentation.utils.Constants;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests of selector deserialization.
+ */
+public class SelectorDeserializerTest extends AbstractTest {
+
+    /**
+     * Tests deserializing AudioContentSelector.
+     */
+    @Test
+    public void testAudioContentSelector() {
+        final JsonObject jsonObject = JsonObject.mapFrom(new AudioContentSelector());
+        final Selector selector = Json.decodeValue(jsonObject.toString(), Selector.class);
+
+        assertEquals(AudioContentSelector.class.getSimpleName(), selector.getType());
+    }
+
+    /**
+     * Tests deserializing VisualContentSelector.
+     */
+    @Test
+    public void testVisualContentSelector() {
+        final JsonObject jsonObject = JsonObject.mapFrom(new VisualContentSelector());
+        final Selector selector = Json.decodeValue(jsonObject.toString(), Selector.class);
+
+        assertEquals(VisualContentSelector.class.getSimpleName(), selector.getType());
+    }
+
+    /**
+     * Tests deserializing FragmentSelector.
+     */
+    @Test
+    public void testFragmentSelector() {
+        final JsonObject jsonObject = JsonObject.mapFrom(new MediaFragmentSelector(0, 0, 50, 50));
+        final MediaFragmentSelector selector = (MediaFragmentSelector) Json.decodeValue(jsonObject.toString(),
+                Selector.class);
+
+        assertEquals(0, selector.getX());
+        assertEquals(50, selector.getWidth());
+    }
+
+    /**
+     * Tests deserializing ImageApiSelector.
+     */
+    @Test
+    public void testImageApiSelector() {
+        final JsonObject jsonObject = JsonObject.mapFrom(new ImageApiSelector());
+        final Selector selector = Json.decodeValue(jsonObject.toString(), Selector.class);
+
+        assertEquals(ImageApiSelector.DEFAULT_REGION, ((ImageApiSelector) selector).getRegion());
+    }
+
+    /**
+     * Tests deserializing JSON without a required <code>type</code> property.
+     */
+    @Test
+    public void testImageApiSelectorMissingType() {
+        final String json = new JsonObject().put(ImageApiSelector.REGION, ImageApiSelector.DEFAULT_REGION).toString();
+
+        assertNull(Json.decodeValue(json, Selector.class));
+    }
+
+    /**
+     * Tests deserializing a partial ImageApiSelector (which is valid).
+     */
+    @Test
+    public void testImageApiSelectorPartialJSON() {
+        final JsonObject jsonObject = new JsonObject().put(ImageApiSelector.REGION, ImageApiSelector.DEFAULT_REGION)
+                .put(Constants.TYPE, ImageApiSelector.class.getSimpleName());
+        final Selector selector = Json.decodeValue(jsonObject.toString(), Selector.class);
+
+        assertEquals(ImageApiSelector.DEFAULT_REGION, ((ImageApiSelector) selector).getRegion());
+    }
+}

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/VisualContentSelectorTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/VisualContentSelectorTest.java
@@ -1,0 +1,30 @@
+
+package info.freelibrary.iiif.presentation.properties.selectors;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests of the visual content selector.
+ */
+public class VisualContentSelectorTest {
+
+    private static final String SELECTOR_NAME = "VisualContentSelector";
+
+    /**
+     * Tests the <code>getType()</code> method of VisualContentSelector.
+     */
+    @Test
+    public final void testGetType() {
+        assertEquals(SELECTOR_NAME, new VisualContentSelector().getType());
+    }
+
+    /**
+     * Tests the <code>toString()</code> method of VisualContentSelector.
+     */
+    @Test
+    public final void testToString() {
+        assertEquals(SELECTOR_NAME, new VisualContentSelector().toString());
+    }
+}


### PR DESCRIPTION
* Change `startCanvas` URI to `start` object (with `Canvas` or `SpecificResource` as its type)
* Move static `DatabindCodec` mapper from `Manifest` and `Collection` up to `Resource`
* Add `start` to Manifest
* Remove `start` from `Sequence` (`Sequence` is going away in a future ticket, fwiw)
* Made thumbnail and logo deserializers package level (to be like the other deserializers)
* Add selectors to `start` (defined at https://iiif.io/api/annex/openannotation/#introduction and https://www.w3.org/TR/annotation-model/#fragment-selector)
* Add selector deserializer
* Add tests of selectors and the selector deserializer