### PR TITLE
[Refactor] Move Constants class to base package

### DIFF
--- a/src/main/java/info/freelibrary/iiif/presentation/Annotation.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Annotation.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import info.freelibrary.iiif.presentation.properties.Behavior;
 import info.freelibrary.iiif.presentation.properties.TimeMode;
 import info.freelibrary.iiif.presentation.properties.behaviors.ResourceBehavior;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 /**
  * Content resources and commentary are associated with a canvas via an annotation. This provides a single, coherent

--- a/src/main/java/info/freelibrary/iiif/presentation/AnnotationList.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/AnnotationList.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 
 import info.freelibrary.iiif.presentation.properties.Behavior;
 import info.freelibrary.iiif.presentation.properties.behaviors.ResourceBehavior;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 /**
  * An ordered list of annotations, typically associated with a single canvas.

--- a/src/main/java/info/freelibrary/iiif/presentation/Canvas.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Canvas.java
@@ -17,7 +17,6 @@ import info.freelibrary.iiif.presentation.properties.Label;
 import info.freelibrary.iiif.presentation.properties.NavDate;
 import info.freelibrary.iiif.presentation.properties.Thumbnail;
 import info.freelibrary.iiif.presentation.properties.behaviors.CanvasBehavior;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 
 /**

--- a/src/main/java/info/freelibrary/iiif/presentation/Collection.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Collection.java
@@ -16,7 +16,6 @@ import info.freelibrary.iiif.presentation.properties.NavDate;
 import info.freelibrary.iiif.presentation.properties.Summary;
 import info.freelibrary.iiif.presentation.properties.Thumbnail;
 import info.freelibrary.iiif.presentation.properties.behaviors.CollectionBehavior;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.util.I18nRuntimeException;
 
 import io.vertx.core.json.Json;

--- a/src/main/java/info/freelibrary/iiif/presentation/Constants.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Constants.java
@@ -1,5 +1,5 @@
 
-package info.freelibrary.iiif.presentation.utils;
+package info.freelibrary.iiif.presentation;
 
 import java.net.URI;
 

--- a/src/main/java/info/freelibrary/iiif/presentation/Content.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Content.java
@@ -7,8 +7,6 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
-
 /**
  * A package-level content class that extends Resource and is extended by other public classes.
  *

--- a/src/main/java/info/freelibrary/iiif/presentation/ImageContent.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/ImageContent.java
@@ -22,7 +22,6 @@ import info.freelibrary.iiif.presentation.properties.Label;
 import info.freelibrary.iiif.presentation.properties.behaviors.ResourceBehavior;
 import info.freelibrary.iiif.presentation.services.APIComplianceLevel;
 import info.freelibrary.iiif.presentation.services.ImageInfoService;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.ImageContentComparator;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.I18nRuntimeException;

--- a/src/main/java/info/freelibrary/iiif/presentation/ImageResource.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/ImageResource.java
@@ -13,7 +13,6 @@ import com.google.common.net.MediaType;
 
 import info.freelibrary.iiif.presentation.properties.Label;
 import info.freelibrary.iiif.presentation.services.ImageInfoService;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 /**
  * An image resource that's used in {@link ImageContent}.

--- a/src/main/java/info/freelibrary/iiif/presentation/Layer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Layer.java
@@ -10,7 +10,6 @@ import info.freelibrary.iiif.presentation.properties.Behavior;
 import info.freelibrary.iiif.presentation.properties.Label;
 import info.freelibrary.iiif.presentation.properties.ViewingDirection;
 import info.freelibrary.iiif.presentation.properties.behaviors.ResourceBehavior;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 /**
  * An ordered list of annotation lists. Layers allow higher level groupings of annotations to be recorded. For

--- a/src/main/java/info/freelibrary/iiif/presentation/Manifest.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Manifest.java
@@ -24,7 +24,6 @@ import info.freelibrary.iiif.presentation.properties.Summary;
 import info.freelibrary.iiif.presentation.properties.Thumbnail;
 import info.freelibrary.iiif.presentation.properties.ViewingDirection;
 import info.freelibrary.iiif.presentation.properties.behaviors.ManifestBehavior;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.I18nRuntimeException;
 

--- a/src/main/java/info/freelibrary/iiif/presentation/OtherContent.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/OtherContent.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 
 import info.freelibrary.iiif.presentation.properties.Behavior;
 import info.freelibrary.iiif.presentation.properties.behaviors.ResourceBehavior;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 /**
  * Other, non-image, resources that are associated with a {@link Canvas}.

--- a/src/main/java/info/freelibrary/iiif/presentation/Range.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Range.java
@@ -13,7 +13,6 @@ import info.freelibrary.iiif.presentation.properties.NavDate;
 import info.freelibrary.iiif.presentation.properties.Start;
 import info.freelibrary.iiif.presentation.properties.ViewingDirection;
 import info.freelibrary.iiif.presentation.properties.behaviors.RangeBehavior;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 /**
  * An ordered list of canvases, and/or further ranges. Ranges allow canvases, or parts thereof, to be grouped together

--- a/src/main/java/info/freelibrary/iiif/presentation/Resource.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Resource.java
@@ -30,7 +30,6 @@ import info.freelibrary.iiif.presentation.properties.SeeAlso;
 import info.freelibrary.iiif.presentation.properties.Summary;
 import info.freelibrary.iiif.presentation.properties.Thumbnail;
 import info.freelibrary.iiif.presentation.services.Service;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/Sequence.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/Sequence.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import info.freelibrary.iiif.presentation.properties.Behavior;
 import info.freelibrary.iiif.presentation.properties.ViewingDirection;
 import info.freelibrary.iiif.presentation.properties.behaviors.ResourceBehavior;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 /**
  * The order of the views of the object. Multiple sequences are allowed to cover situations when there are multiple

--- a/src/main/java/info/freelibrary/iiif/presentation/ServiceImage.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/ServiceImage.java
@@ -1,7 +1,7 @@
 
 package info.freelibrary.iiif.presentation;
 
-import static info.freelibrary.iiif.presentation.utils.Constants.BUNDLE_NAME;
+import static info.freelibrary.iiif.presentation.Constants.BUNDLE_NAME;
 
 import java.net.URI;
 import java.util.Objects;
@@ -19,7 +19,6 @@ import info.freelibrary.iiif.presentation.properties.Logo;
 import info.freelibrary.iiif.presentation.properties.Thumbnail;
 import info.freelibrary.iiif.presentation.services.ImageInfoService;
 import info.freelibrary.iiif.presentation.services.Service;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.FileUtils;
 import info.freelibrary.util.Logger;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Homepage.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Homepage.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 /**
  * A web page that is about the object represented by the resource that has the <code>homepage</code> property. The web

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/I18n.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/I18n.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableMap;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.I18nUtils;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/I18nEntry.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/I18nEntry.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Label.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Label.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.I18nUtils;
 
 /**

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Localized.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Localized.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Logo.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Logo.java
@@ -6,8 +6,8 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.services.ImageInfoService;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 /**
  * A small image that represents an individual or organization associated with the resource it is attached to. This

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/LogoDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/LogoDeserializer.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Metadata.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Metadata.java
@@ -7,7 +7,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/MetadataDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/MetadataDeserializer.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/PartOf.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/PartOf.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 /**
  * A containing resource that includes the resource that has the <code>partOf</code> property. For example, the

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Rendering.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Rendering.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 /**
  * A resource that is an alternative, non-IIIF representation of the resource that has the <code>rendering</code>

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/RequiredStatement.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/RequiredStatement.java
@@ -7,7 +7,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/RequiredStatementDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/RequiredStatementDeserializer.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/SeeAlso.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/SeeAlso.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.MediaType;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Start.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Start.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.properties.selectors.Selector;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 /**
  * A Canvas, or part of a Canvas, which the client should show on initialization for the resource that has the start

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Summary.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Summary.java
@@ -4,7 +4,7 @@ package info.freelibrary.iiif.presentation.properties;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 /**
  * A short textual summary intended to be conveyed to the user when the metadata entries for the resource are not

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Thumbnail.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Thumbnail.java
@@ -6,8 +6,8 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.services.ImageInfoService;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 /**
  * A small image that depicts or pictorially represents the resource that the property is attached to, such as the

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/ThumbnailDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/ThumbnailDeserializer.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/Value.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/Value.java
@@ -3,7 +3,7 @@ package info.freelibrary.iiif.presentation.properties;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 /**
  * A human readable internationalized value.

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/ViewingDirection.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/ViewingDirection.java
@@ -3,7 +3,7 @@ package info.freelibrary.iiif.presentation.properties;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/AbstractSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/AbstractSelector.java
@@ -3,7 +3,7 @@ package info.freelibrary.iiif.presentation.properties.selectors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 /**
  * An abstract selector that other selectors can extend.

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/ImageApiSelector.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/ImageApiSelector.java
@@ -1,7 +1,7 @@
 
 package info.freelibrary.iiif.presentation.properties.selectors;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/SelectorDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/properties/selectors/SelectorDeserializer.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 /**
  * A deserializer for classes that implement the Selector interface.

--- a/src/main/java/info/freelibrary/iiif/presentation/services/APIComplianceLevel.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/services/APIComplianceLevel.java
@@ -5,7 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.util.I18nRuntimeException;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/services/GenericService.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/services/GenericService.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.MediaType;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.FileUtils;
 import info.freelibrary.util.Logger;

--- a/src/main/java/info/freelibrary/iiif/presentation/services/GeoJSONService.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/services/GeoJSONService.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 /**
  * An external service that provides GeoJSON information.

--- a/src/main/java/info/freelibrary/iiif/presentation/services/ImageInfoService.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/services/ImageInfoService.java
@@ -6,7 +6,7 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 /**
  * A service that will return information about a particular image.

--- a/src/main/java/info/freelibrary/iiif/presentation/services/PhysicalDimsService.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/services/PhysicalDimsService.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 /**
  * A physical dimensions service that provides information useful for rulers, etc.

--- a/src/main/java/info/freelibrary/iiif/presentation/services/ServiceDeserializer.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/services/ServiceDeserializer.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/utils/I18nUtils.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/utils/I18nUtils.java
@@ -15,6 +15,7 @@ import org.jsoup.parser.Parser;
 import org.jsoup.safety.Cleaner;
 import org.jsoup.safety.Whitelist;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.properties.I18n;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/main/java/info/freelibrary/iiif/presentation/utils/ImageContentComparator.java
+++ b/src/main/java/info/freelibrary/iiif/presentation/utils/ImageContentComparator.java
@@ -4,6 +4,8 @@ package info.freelibrary.iiif.presentation.utils;
 import java.util.Comparator;
 import java.util.Objects;
 
+import info.freelibrary.iiif.presentation.Constants;
+
 /**
  * A comparator that returns the sort order of the {@code ImageContent} properties.
  */

--- a/src/test/java/info/freelibrary/iiif/presentation/ResourceTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/ResourceTest.java
@@ -28,7 +28,6 @@ import info.freelibrary.iiif.presentation.properties.behaviors.CollectionBehavio
 import info.freelibrary.iiif.presentation.properties.behaviors.ManifestBehavior;
 import info.freelibrary.iiif.presentation.properties.behaviors.ResourceBehavior;
 import info.freelibrary.iiif.presentation.services.ImageInfoService;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.ResourceTypes;
 
 import io.vertx.core.json.JsonObject;

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/HomepageTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/HomepageTest.java
@@ -13,8 +13,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.Manifest;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.ResourceTypes;
 import info.freelibrary.iiif.presentation.utils.TestUtils;
 import info.freelibrary.util.StringUtils;

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/I18nTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/I18nTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 
 import com.thedeanda.lorem.LoremIpsum;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/LabelTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/LabelTest.java
@@ -9,8 +9,8 @@ import org.junit.Test;
 import com.thedeanda.lorem.LoremIpsum;
 
 import info.freelibrary.iiif.presentation.AbstractTest;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.Manifest;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/LogoTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/LogoTest.java
@@ -12,8 +12,8 @@ import org.junit.Test;
 
 import com.google.common.net.MediaType;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.services.ImageInfoService;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.TestUtils;
 import info.freelibrary.util.StringUtils;
 

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/MetadataTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/MetadataTest.java
@@ -6,8 +6,8 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.Manifest;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/PartOfTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/PartOfTest.java
@@ -13,8 +13,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.Manifest;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.ResourceTypes;
 import info.freelibrary.iiif.presentation.utils.TestUtils;
 import info.freelibrary.util.StringUtils;

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/RenderingTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/RenderingTest.java
@@ -13,8 +13,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.Manifest;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.ResourceTypes;
 import info.freelibrary.iiif.presentation.utils.TestUtils;
 import info.freelibrary.util.StringUtils;

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/RequiredStatementTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/RequiredStatementTest.java
@@ -6,8 +6,8 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.Manifest;
-import info.freelibrary.iiif.presentation.utils.Constants;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/StartTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/StartTest.java
@@ -9,8 +9,8 @@ import com.thedeanda.lorem.Lorem;
 import com.thedeanda.lorem.LoremIpsum;
 
 import info.freelibrary.iiif.presentation.AbstractTest;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.properties.selectors.AudioContentSelector;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.util.StringUtils;
 
 import io.vertx.core.json.JsonObject;

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/ThumbnailTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/ThumbnailTest.java
@@ -11,8 +11,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.services.ImageInfoService;
-import info.freelibrary.iiif.presentation.utils.Constants;
 import info.freelibrary.iiif.presentation.utils.TestUtils;
 import info.freelibrary.util.StringUtils;
 

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/ViewingDirectionTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/ViewingDirectionTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 import info.freelibrary.iiif.presentation.utils.MessageCodes;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/PointSelectorTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/PointSelectorTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import info.freelibrary.iiif.presentation.AbstractTest;
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 import io.vertx.core.json.JsonObject;
 

--- a/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/SelectorDeserializerTest.java
+++ b/src/test/java/info/freelibrary/iiif/presentation/properties/selectors/SelectorDeserializerTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
 import info.freelibrary.iiif.presentation.AbstractTest;
-import info.freelibrary.iiif.presentation.utils.Constants;
+import info.freelibrary.iiif.presentation.Constants;
 
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;


### PR DESCRIPTION
Isolated refactor to move Constants class from the utils folder back into the back package for the library. This PR just has this refactor, no functional changes or syntactical changes.