### PR TITLE
[IIIF-781] Update parent project version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>3.8.10</version>
+    <version>3.9.0</version>
   </parent>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>3.9.0</version>
+    <version>4.0.0</version>
   </parent>
 
 </project>

--- a/src/main/tools/checkstyle/checkstyle.xml
+++ b/src/main/tools/checkstyle/checkstyle.xml
@@ -8,6 +8,7 @@
   <property name="severity" value="warning" />
   <module name="LineLength">
     <property name="max" value="120" />
+    <property name="fileExtensions" value="java, py, sh, txt"/>
   </module>
   <module name="TreeWalker">
     <module name="RedundantImport" />


### PR DESCRIPTION
* Update the version of the parent project, which pulls in an updated Checkstyle fix that should get Eclipse Checkstyle to stop warning about line length on PNG, etc., files.
* The project version update also lets Travis deploy snapshot artifacts to a snapshot Maven repo